### PR TITLE
feat: 개선된 workflow 추가

### DIFF
--- a/Template/prompts.py
+++ b/Template/prompts.py
@@ -1,63 +1,143 @@
 from langchain.prompts import PromptTemplate
 
+
+# **(임시)**질문 생성을 위한 프롬프트 템플릿
+##########################################################
+question_generation_prompt = PromptTemplate(
+    input_variables=["question"],
+    template="""사용자 질문: {question}
+
+위 질문을 더 구체적으로 작성하세요."""
+)
+##########################################################
+
+# 직무 검증을 위한 프롬프트 템플릿
 job_recommendation_prompt = PromptTemplate(
-    input_variables=["user_profile", "job_list"],
-    template="""사용자 프로필: {user_profile}
+    input_variables=[
+        "user_profile",
+        "회사 1", "직무 1", "위치 1", "자격 요건 1", "우대 사항 1", "원본 1", "코사인유사도 1",
+        "회사 2", "직무 2", "위치 2", "자격 요건 2", "우대 사항 2", "원본 2", "코사인유사도 2",
+        "회사 3", "직무 3", "위치 3", "자격 요건 3", "우대 사항 3", "원본 3", "코사인유사도 3",
+        "회사 4", "직무 4", "위치 4", "자격 요건 4", "우대 사항 4", "원본 4", "코사인유사도 4",
+        "회사 5", "직무 5", "위치 5", "자격 요건 5", "우대 사항 5", "원본 5", "코사인유사도 5"
+    ],
+    template="""
+사용자 프로필:
+{user_profile}
 
-직무 목록 (각 직무는 직무, 회사, 직무 카테고리, 태그, 위치, 마감일, 포지션 상세, 주요 업무, 자격 요건, 우대 사항, 기술 스택, 혜택 및 복지, 채용 과정, 채용공고 URL 포함):
-{job_list}
+아래는 추천 후보 직무 목록입니다. 각 직무의 '회사', '직무', '위치', '자격 요건', '우대 사항', '유사도 점수' 정보를 참고하세요.
 
-사용자의 프로필과 질문에 가장 적합한 직무를 추천하고, 추천 이유를 직무 정보(직무, 회사, 기술 스택, 자격 요건 등)를 기반으로 설명하세요."""
+각 직무별로 아래 3가지 항목에 대해 사용자 프로필과 일치하는지 0 또는 1로 판단하세요.
+
+1.  **희망 직무 매칭**: 사용자 프로필의 '희망 직무'와 채용 공고의 '{직무 1}'가 의미상 일치하는가?
+2.  **기술 스택 매칭**: 사용자 프로필의 '기술 스택'이 채용 공고의 '{자격 요건 1}' 또는 '{우대 사항 1}' 내용과 일치하는가?
+3.  **희망 근무지 매칭**: 사용자 프로필의 '희망 근무지'와 채용 공고의 '{위치 1}'가 일치하는가?
+    (규칙: '서울'과 '서울시'처럼 시(City) 단위로 일치하거나, 수도권(서울, 경기, 인천) / 비수도권 단위로 일치하는 경우도 매칭(1)으로 인정한다.)
+
+위의 매칭 점수(0/1) 합계(최대 3점)와 코사인 유사도 점수를 다음 공식에 따라 가중 평균하여 최종 점수를 계산하세요.
+**최종 점수 = (매칭 점수 합계 / 3 * 0.5 + 코사인 유사도 점수 * 0.5)**
+
+---
+[분석 과정]
+각 직무별로 아래와 같이 표로 정리하여 분석 과정을 보여주세요.
+
+1) 회사: {회사 1}
+   - 매칭 점수: (희망 직무: 0/1, 기술 스택: 0/1, 희망 근무지: 0/1)
+   - 매칭 점수 합계: (예: 2)
+   - 코사인 유사도 점수: {코사인유사도 1}
+   - 최종 점수: (계산 결과)
+
+2) 회사: {회사 2}
+   - 매칭 점수: (희망 직무: 0/1, 기술 스택: 0/1, 희망 근무지: 0/1)
+   - 매칭 점수 합계: (예: 3)
+   - 코사인 유사도 점수: {코사인유사도 2}
+   - 최종 점수: (계산 결과)
+
+3) 회사: {회사 3}
+   - 매칭 점수: (희망 직무: 0/1, 기술 스택: 0/1, 희망 근무지: 0/1)
+   - 매칭 점수 합계: (예: 3)
+   - 코사인 유사도 점수: {코사인유사도 3}
+   - 최종 점수: (계산 결과)
+
+4) 회사: {회사 4}
+   - 매칭 점수: (희망 직무: 0/1, 기술 스택: 0/1, 희망 근무지: 0/1)
+   - 매칭 점수 합계: (예: 3)
+   - 코사인 유사도 점수: {코사인유사도 4}
+   - 최종 점수: (계산 결과)
+
+5) 회사: {회사 5}
+   - 매칭 점수: (희망 직무: 0/1, 기술 스택: 0/1, 희망 근무지: 0/1)
+   - 매칭 점수 합계: (예: 3)
+   - 코사인 유사도 점수: {코사인유사도 5}
+   - 최종 점수: (계산 결과)
+---
+
+[최종 답변]
+최종적으로 아래와 같은 JSON 형식으로만 답변하세요.
+
+{{
+  "selected_job_index": "가장 점수가 높은 직무의 번호 (1에서 5 사이의 숫자)",
+  "selected_job_reason": "각 항목별 매칭 근거와 점수 계산 과정, 그리고 최종적으로 해당 직무를 선정한 이유를 구체적으로 작성하세요."
+}}
+"""
 )
-
-company_info_prompt = PromptTemplate(
-    input_variables=["company_data"],
-    template="""회사 정보 (포지션 상세 포함):
-{company_data}
-
-위 정보를 바탕으로 회사 개요를 간결히 작성하세요."""
-)
-
-salary_info_prompt = PromptTemplate(
-    input_variables=["job_data", "search_results"],
-    template="""직무 정보 (직무, 회사 포함):
-{job_data}
-
-검색 결과:
-{search_results}
-
-위 정보를 바탕으로 급여 정보를 요약하세요."""
-)
+##########################################################
 
 preparation_advice_prompt = PromptTemplate(
     input_variables=["user_profile", "job_data"],
     template="""사용자 프로필: {user_profile}
 
-직무 정보 (직무, 회사, 주요 업무, 자격 요건, 기술 스택, 혜택 및 복지 등 포함):
+직무 정보 (직무, 회사, 주요 업무, 자격 요건, 기술 스택, 혜택 및 복지, 희망 근무지, 채용 과정 등 포함):
 {job_data}
 
 위 정보를 바탕으로 직무 준비 조언을 제공하세요."""
 )
 
 summary_memory_prompt = PromptTemplate(
-    input_variables=["job_recommendations", "company_info", "salary_info", "preparation_advice", "chat_history"],
-    template="추천: {job_recommendations}\n회사: {company_info}\n급여: {salary_info}\n조언: {preparation_advice}\n대화: {chat_history}\n요약하세요."
+    input_variables=["selected_job", "search_result", "preparation_advice", "chat_history"],
+    template="추천 회사: {selected_job}\검색 정보: {search_result}\n조언: {preparation_advice}\n대화: {chat_history}\n요약하세요."
 )
 
+# 최종 답변 생성을 위한 프롬프트 템플릿
+final_answer_prompt = PromptTemplate(
+    input_variables=["selected_job","search_result", "preparation_advice"],
+    template="""당신은 사용자의 직무 상담을 도와주는 AI 어시스턴트입니다.
+다음 정보를 바탕으로 사용자에게 최종 답변을 제공해주세요:
+
+1. 회사 정보
+2. 인터넷 검색 추가 정보
+3. 준비 조언
+
+위 정보들을 자연스럽게 통합하여, 사용자가 이해하기 쉽고 실질적인 도움이 되는 답변을 작성해주세요.
+답변은 친절하고 전문적이어야 하며, 사용자의 상황에 맞는 구체적인 조언을 포함해야 합니다.
+
+주의사항:
+- 제공된 정보만을 사용하여 답변하세요.
+- 정보가 부족하거나 불확실한 경우, 해당 부분에 대해 "해당 정보를 제공할 수 없습니다"라고 명시적으로 언급하세요.
+- 정보가 전혀 없는 경우, "죄송합니다. 현재 제공된 정보로는 적절한 답변을 드리기 어렵습니다"라고 답변하세요.
+- 절대로 제공되지 않은 정보를 임의로 추측하거나 만들어내지 마세요.
+
+추천 회사: {selected_job}
+검색 결과: {search_result}
+조언: {preparation_advice}"""
+)
+
+# 직무 검증을 위한 프롬프트 템플릿
+##########################################################
 job_verification_prompt = PromptTemplate(
-    input_variables=["user_profile", "question", "job_documents"],
-    template="""사용자 프로필: {user_profile}
+    input_variables=["user_profile", "question", "job_document"],
+    template="""
+사용자 프로필: {user_profile}
 질문: {question}
 직무 문서 (직무, 회사, 직무 카테고리, 태그, 위치, 마감일, 포지션 상세, 주요 업무, 자격 요건, 우대 사항, 기술 스택, 혜택 및 복지, 채용 과정, 채용공고 URL 포함):
-{job_documents}
+{job_document}
 
-위 문서가 사용자의 질문과 프로필에 적합한지 평가하세요. 적합하면 "is_relevant: true"를, 적합하지 않으면 "is_relevant: false"와 함께 수정된 검색 쿼리("revised_query")를 JSON 형식으로 반환하세요. 예시 형식:
-
-{{
-  "is_relevant": false,
-  "revised_query": "프롬프트 엔지니어 직무 한국"
-}}"""
+위 문서가 사용자의 질문과 프로필에 적합한지 평가하세요. 적합하면 반드시 소문자 true, 적합하지 않으면 반드시 소문자 false만을 출력하세요. (예: true 또는 false)
+다른 부가 설명, JSON, 문장 등은 절대 출력하지 마세요.
+"""
 )
+
+##########################################################
 
 react_prompt = PromptTemplate(
     input_variables=["input", "agent_scratchpad", "tools", "tool_names"],

--- a/WorkFlow/Util/utils.py
+++ b/WorkFlow/Util/utils.py
@@ -1,7 +1,7 @@
 from typing import Dict, List, Any, Callable
 from langchain_core.runnables import RunnableSequence
 from config import get_llm
-from Template.prompts import job_recommendation_prompt, company_info_prompt, salary_info_prompt, preparation_advice_prompt, summary_memory_prompt, job_verification_prompt
+from Template.prompts import job_recommendation_prompt, preparation_advice_prompt, summary_memory_prompt, job_verification_prompt, final_answer_prompt, question_generation_prompt
 from langchain_community.chat_message_histories import ChatMessageHistory
 
 # 대화 메모리
@@ -28,11 +28,11 @@ class RunInvokeAdapter:
 
 # llm chain (각 체인에 run 메소드 제공)
 job_chain = RunInvokeAdapter(job_recommendation_prompt | llm)
-company_chain = RunInvokeAdapter(company_info_prompt | llm)
-salary_chain = RunInvokeAdapter(salary_info_prompt | llm)
 advice_chain = RunInvokeAdapter(preparation_advice_prompt | llm)
 verify_job_chain = RunInvokeAdapter(job_verification_prompt | llm)
+final_answer_chain = RunInvokeAdapter(final_answer_prompt | llm)
 summary_memory_chain = RunInvokeAdapter(summary_memory_prompt | llm)
+question_generation_chain = RunInvokeAdapter(question_generation_prompt | llm)
 
 # Graph 상태 타입 정의
 class GraphState(Dict):

--- a/WorkFlow/main.py
+++ b/WorkFlow/main.py
@@ -19,11 +19,12 @@ os.environ["LANGCHAIN_ENDPOINT"] = "https://api.smith.langchain.com"
 def invoke_workflow():
     """LangGraph 기반으로 워크플로우 실행."""
     user_input = {
-        "candidate_major": "컴퓨터 과학",
-        "candidate_interest": "AI 엔지니어",
-        "candidate_career": "신입",
-        "candidate_tech_stack": ["Python", "TensorFlow", "PyTorch"],
-        "candidate_question": "프롬프트 엔지니어링 관련 직무는 뭐가 있을까?"
+        "candidate_major": "통계학과 및 수학과",
+        "candidate_interest": "수학과 교수",
+        "candidate_career": "수학과 박사 졸업",
+        "candidate_tech_stack": ["Latex", "위상수학", "대수학", "해석학", "미적분학", "확률론"],
+        "candidate_location": "서울",
+        "candidate_question": "현재 수학과 박사 졸업했고, 수학과 박사를 원하는 회사가 있을까?"
     }
     
     try:
@@ -45,6 +46,8 @@ def invoke_workflow():
         print("\n=== LangSmith 추적 정보 ===")
         print(f"프로젝트: {os.getenv('LANGSMITH_PROJECT', 'job_advisor')}")
         print("자세한 실행 로그는 LangSmith 대시보드에서 확인하세요: https://smith.langchain.com")
+
+        return result.get("final_answer", "결과 없음")
         
     except Exception as e:
         logger.error("Workflow error: %s", str(e))

--- a/WorkFlow/tests/integration/test_workflow_integration.py
+++ b/WorkFlow/tests/integration/test_workflow_integration.py
@@ -1,6 +1,6 @@
 import pytest
 from datetime import datetime
-from WorkFlow.SLD.workflow import (
+from WorkFlow.SLD.tools import (
     parse_input, recommend_jobs, get_company_info,
     get_salary_info, get_preparation_advice, summarize_results
 )

--- a/WorkFlow/tests/unit/test_workflow_nodes.py
+++ b/WorkFlow/tests/unit/test_workflow_nodes.py
@@ -1,6 +1,6 @@
 import pytest
 from datetime import datetime
-from WorkFlow.SLD.workflow import (
+from WorkFlow.SLD.tools import (
     parse_input, recommend_jobs, get_company_info,
     get_salary_info, get_preparation_advice, summarize_results
 )

--- a/retrieval/embeddings.py
+++ b/retrieval/embeddings.py
@@ -17,3 +17,14 @@ def get_vector_store():
     index = get_pinecone()
     return PineconeVectorStore(index=index, embedding=embeddings)
 
+def retrieve(query: str, top_k: int = 5):
+    embeddings = get_embeddings()
+    query_vector = embeddings.embed_query(query)
+
+    index = get_pinecone()
+    results = index.query(vector=query_vector, top_k=top_k, include_values=False, include_metadata=True)
+
+    distances = [x['score'] for x in results['matches']]
+    meta_data_li = [x['metadata'] for x in results['matches']]
+    text_data_li = [x['text'] for x in meta_data_li]
+    return distances, text_data_li


### PR DESCRIPTION
1. job_recommendation_prompt.py 참조: 직무/근무지/자격요건과 임베딩 벡터 코사인 유사도 점수간의 가중평균으로 문서 선정하는 로직 구현
2. 급여 검색 -> 회사명 + 사용자 질문으로 쿼리 만들어서 인터넷 검색으로 변경

개선해야 할점.
job_recommendation_prompt에서 각 요건별로 더 세밀한 가중치 조정
preparation_advice_prompt는 사용자 질문 + 문서를 봐서 사용자가 준비해야할 점을 조언하는 프롬프트인데 사용자가 회사 정보를 조회하기 전에 미리 조언 정보가 담겨 있어서 질문 쿼리와 맥락에 맞지 않는 답변을 내놓는다. 이를 개선해야 한다.
final_answer_prompt에서 우리가 원하는 답변 양식으로 프롬프트를 조정해야 한다. json형식으로 출력하고, 답변은 따로 키를 빼서 거기서 답변하도록; 그리고 답변 양식을 정해야할 듯 하다.
question_generation_prompt: 현재 리트리버 검색 top 5선정 -> 가중평균으로 문서 점수 계산해서 top-1 선정 -> 질문/문서 적합도 판단 -> 불일치 시 질문을 디테일하게 생성해서 다시 위를 반복하여, top 1 선정하는 로직; 이에 현재 프롬프트는 "위 질문을 더 구체적으로 작성하세요" 식인데 이를 개선해야 한다. 또한 현재 재검색 절차후 문서 선정은 덮어쓰기 형식이라 앞이 좋은 문서여도 이후 문서로 선정된다는 문제가 존재한다.